### PR TITLE
adding maven spotbugs plugin to pom.xml

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -25,7 +25,7 @@ jobs:
         run: mvn -B verify spotbugs:spotbugs
       - uses: jwgmeligmeyling/spotbugs-github-action@v1.2
           with:
-            path: '**/spotbugsXml.xml'
+            paths: '**/spotbugsXml.xml'
 
       - name: Generate JaCoCo Badge
         id: jacoco

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         run: sudo apt-get -y -q --no-install-recommends install ffmpeg mediainfo tesseract-ocr tesseract-ocr-deu
       - name: Build with Maven
         run: mvn -B verify spotbugs:spotbugs
-      - uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
           with:
             paths: '**/spotbugsXml.xml'
 

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         run: sudo apt-get -y -q --no-install-recommends install ffmpeg mediainfo tesseract-ocr tesseract-ocr-deu
       - name: Build with Maven
         run: mvn -B verify spotbugs:spotbugs
-      - uses: jwgmeligmeyling/spotbugs-github-action@master
+      - uses: jwgmeligmeyling/spotbugs-github-action@v1.2
           with:
             path: '**/spotbugsXml.xml'
 

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Install test dependencies
         run: sudo apt-get -y -q --no-install-recommends install ffmpeg mediainfo tesseract-ocr tesseract-ocr-deu
       - name: Build with Maven
-        run: mvn -B clean test
+        run: mvn -B verify spotbugs:spotbugs
+      - uses: jwgmeligmeyling/spotbugs-github-action@master
+          with:
+            path: '**/spotbugsXml.xml'
 
       - name: Generate JaCoCo Badge
         id: jacoco

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -23,9 +23,9 @@ jobs:
         run: sudo apt-get -y -q --no-install-recommends install ffmpeg mediainfo tesseract-ocr tesseract-ocr-deu
       - name: Build with Maven
         run: mvn -B verify spotbugs:spotbugs
-        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
-          with:
-            paths: '**/spotbugsXml.xml'
+      - uses: jwgmeligmeyling/spotbugs-github-action@master
+        with:
+          path: '**/spotbugsXml.xml'
 
       - name: Generate JaCoCo Badge
         id: jacoco

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,24 @@
           <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.7.3.0</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+          <xmlOutput>true</xmlOutput>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       
       <plugin>
         <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,19 +112,17 @@
         </configuration>
       </plugin>
 
-<build>
-  <plugins>
-    <plugin>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-maven-plugin</artifactId>
-      <version>4.0.0</version>
-      <configuration>
-        <xmlOutput>true</xmlOutput>
-        <failOnError>false</failOnError>
-      </configuration>
-    </plugin>
-  </plugins>
-</build>
+      <plugins>
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>4.0.0</version>
+          <configuration>
+            <xmlOutput>true</xmlOutput>
+            <failOnError>false</failOnError>
+          </configuration>
+        </plugin>
+      </plugins>
       
       <plugin>
         <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,17 +112,16 @@
         </configuration>
       </plugin>
 
-      <plugins>
-        <plugin>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.0.0</version>
-          <configuration>
-            <xmlOutput>true</xmlOutput>
-            <failOnError>false</failOnError>
-          </configuration>
-        </plugin>
-      </plugins>
+
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.0.0</version>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>false</failOnError>
+        </configuration>
+      </plugin>
       
       <plugin>
         <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,23 +112,19 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.7.3.0</version>
-        <configuration>
-          <effort>Max</effort>
-          <threshold>Low</threshold>
-          <xmlOutput>true</xmlOutput>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+<build>
+  <plugins>
+    <plugin>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-maven-plugin</artifactId>
+      <version>4.0.0</version>
+      <configuration>
+        <xmlOutput>true</xmlOutput>
+        <failOnError>false</failOnError>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
       
       <plugin>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
EDIT: This plugin has now been fully integrated into the workflow system and runs through build-deploy.yml. The build does not fail if it finds any bugs, but a report is generated of all low/medium/high risk issues that SpotBugs finds and shown on the workflow page.

Previous description:
This adds the SpotBugs plugin to the repository, where it stops the build if it finds any errors. 
To run in CLI: 
       mvn spotbugs:check
